### PR TITLE
Make loading state more obvious

### DIFF
--- a/src/components/github-charts.tsx
+++ b/src/components/github-charts.tsx
@@ -10,6 +10,7 @@ import { endOfYear } from "date-fns";
 import { startOfYear } from "date-fns";
 import { useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
+import { Loader2 } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -86,7 +87,17 @@ export function GitHubCharts({ username }: { username: string }) {
         </Select>
       </div>
       <div className="space-y-8">
-        <div className="overflow-x-auto scrollbar-thin scrollbar-thumb-muted scrollbar-track-transparent">
+        <div className="relative overflow-x-auto scrollbar-thin scrollbar-thumb-muted scrollbar-track-transparent">
+          {isLoading && (
+            <div className="absolute inset-0 flex items-center justify-center backdrop-blur-sm z-10">
+              <div className="flex flex-col items-center gap-2">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                <span className="text-sm text-muted-foreground">
+                  Loading contribution data...
+                </span>
+              </div>
+            </div>
+          )}
           <div
             className={cn(
               "min-w-[700px]",
@@ -103,15 +114,25 @@ export function GitHubCharts({ username }: { username: string }) {
             />
           </div>
         </div>
-        <div className="border-t pt-4 overflow-x-auto scrollbar-thin scrollbar-thumb-muted scrollbar-track-transparent">
+        <div className="space-y-4">
+          <h4 className="text-sm font-medium text-muted-foreground">
+            Weekly Pull Request Counts
+          </h4>
           <div
             className={cn(
-              "min-w-[700px]",
-              isLoading
-                ? "animate-pulse opacity-70 pointer-events-none select-none"
-                : ""
+              "relative min-w-[700px] border-t pt-4 overflow-x-auto scrollbar-thin scrollbar-thumb-muted scrollbar-track-transparent"
             )}
           >
+            {isLoading && (
+              <div className="absolute inset-0 flex items-center justify-center backdrop-blur-sm z-10">
+                <div className="flex flex-col items-center gap-2">
+                  <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">
+                    Loading PR data...
+                  </span>
+                </div>
+              </div>
+            )}
             <GitHubPRChart
               chartData={data?.pullRequestContributions ?? prPlaceholderData}
             />

--- a/src/components/github-charts.tsx
+++ b/src/components/github-charts.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { api } from "@/trpc/react";
-import Link from "next/link";
 import GitHubContributionCalendar from "./github-contribution-calendar";
 import { GitHubPRChart } from "./github-pr-chart";
 import { addDays, format, startOfWeek, getYear } from "date-fns";

--- a/src/components/github-charts.tsx
+++ b/src/components/github-charts.tsx
@@ -66,35 +66,25 @@ export function GitHubCharts({ username }: { username: string }) {
   return (
     <div className="mt-8 rounded-xl border bg-card p-6 shadow-sm">
       <div className="mb-6 flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <h3 className="text-lg font-semibold tracking-tight">
-            GitHub Activity
-          </h3>
-          <Select
-            value={selectedYear.toString()}
-            onValueChange={(value) => setSelectedYear(parseInt(value))}
-            disabled={!userData}
-          >
-            <SelectTrigger className="w-[100px]">
-              <SelectValue placeholder="Select year" />
-            </SelectTrigger>
-            <SelectContent>
-              {availableYears.map((year) => (
-                <SelectItem key={year} value={year.toString()}>
-                  {year}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <Link
-          href={`https://github.com/${username}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-sm text-muted-foreground transition-colors hover:text-foreground hover:underline"
+        <h3 className="text-lg font-semibold tracking-tight">
+          GitHub Activity
+        </h3>
+        <Select
+          value={selectedYear.toString()}
+          onValueChange={(value) => setSelectedYear(parseInt(value))}
+          disabled={!userData}
         >
-          View Profile →
-        </Link>
+          <SelectTrigger className="w-[100px]">
+            <SelectValue placeholder="Select year" />
+          </SelectTrigger>
+          <SelectContent>
+            {availableYears.map((year) => (
+              <SelectItem key={year} value={year.toString()}>
+                {year}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
       <div className="space-y-8">
         <div className="overflow-x-auto scrollbar-thin scrollbar-thumb-muted scrollbar-track-transparent">

--- a/src/components/github-charts.tsx
+++ b/src/components/github-charts.tsx
@@ -98,14 +98,7 @@ export function GitHubCharts({ username }: { username: string }) {
               </div>
             </div>
           )}
-          <div
-            className={cn(
-              "min-w-[700px]",
-              isLoading
-                ? "animate-pulse opacity-70 pointer-events-none select-none"
-                : ""
-            )}
-          >
+          <div className="min-w-[700px]">
             <GitHubContributionCalendar
               contributionCalendarData={
                 data?.contributionCalendar ??

--- a/src/components/github-pr-chart.tsx
+++ b/src/components/github-pr-chart.tsx
@@ -23,48 +23,39 @@ export function GitHubPRChart({
   chartData: GithubContributionData["pullRequestContributions"];
 }) {
   return (
-    <div className="space-y-4">
-      <h4 className="text-sm font-medium text-muted-foreground">
-        Weekly Pull Request Counts
-      </h4>
-      <ChartContainer config={chartConfig} className="h-[180px] w-full">
-        <BarChart accessibilityLayer data={chartData}>
-          <CartesianGrid
-            vertical={false}
-            strokeDasharray="4"
-            className="stroke-border"
-          />
-          <XAxis
-            dataKey="weekStart"
-            tickLine={false}
-            tickMargin={8}
-            axisLine={false}
-            interval={0}
-            tickFormatter={getMonthStartLabel}
-            textAnchor="start"
-            className="text-xs fill-muted-foreground text-start"
-          />
-          <YAxis
-            dataKey="count"
-            tickLine={false}
-            axisLine={false}
-            tickCount={5}
-            tickMargin={8}
-            className="text-xs fill-muted-foreground"
-            width={25}
-          />
-          <ChartTooltip
-            cursor={false}
-            content={<ChartTooltipContent labelFormatter={getWeekLabel} />}
-          />
-          <Bar
-            dataKey="count"
-            fill="var(--color-count)"
-            radius={[4, 4, 0, 0]}
-          />
-        </BarChart>
-      </ChartContainer>
-    </div>
+    <ChartContainer config={chartConfig} className="h-[180px] w-full">
+      <BarChart accessibilityLayer data={chartData}>
+        <CartesianGrid
+          vertical={false}
+          strokeDasharray="4"
+          className="stroke-border"
+        />
+        <XAxis
+          dataKey="weekStart"
+          tickLine={false}
+          tickMargin={8}
+          axisLine={false}
+          interval={0}
+          tickFormatter={getMonthStartLabel}
+          textAnchor="start"
+          className="text-xs fill-muted-foreground text-start"
+        />
+        <YAxis
+          dataKey="count"
+          tickLine={false}
+          axisLine={false}
+          tickCount={5}
+          tickMargin={8}
+          className="text-xs fill-muted-foreground"
+          width={25}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent labelFormatter={getWeekLabel} />}
+        />
+        <Bar dataKey="count" fill="var(--color-count)" radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ChartContainer>
   );
 }
 


### PR DESCRIPTION
- moves the `Weekly Pull Request Counts` out of the `GitHubPRChart` comp to the `GitHubCharts` comp
- add overlays on charts to make it more clear when data is being loaded
- remove pulsing animation from charts